### PR TITLE
Use multistage Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,17 @@
+# builder
+FROM python:3-alpine AS zipper
+
+RUN apk update && apk add make
+
+COPY ./ /app
+RUN make -C /app build/tpl
+
+# final image
 FROM python:3-alpine
 
-COPY dist/tpl /usr/bin/tpl
+COPY --from=zipper /app/dist/tpl /usr/bin/tpl
 RUN ln -s /usr/bin/tpl /entrypoint
 
-CMD ["tpl", "--environment", "-","-"]
+ENTRYPOINT ["tpl"]
+
+CMD ["--environment", "-","-"]


### PR DESCRIPTION
This way the image creation is independent from the host system it is created on. It also should work with DockerHub automated builds and still create a slim image.

With the new entrypoint it would also allow us to use the image name as a kind of command name. `docker run m3t0r/tpl tpl -` would become `docker run m3t0r/tpl -`.